### PR TITLE
Address feedback on token ownership.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "casper-erc20"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "casper-contract",

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-erc20"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["Michał Papierski <michal@casperlabs.io>"]
 description = "A library for developing ERC20 tokens for the Casper network."

--- a/erc20/src/address.rs
+++ b/erc20/src/address.rs
@@ -36,8 +36,8 @@ impl Address {
 }
 
 impl From<ContractPackageHash> for Address {
-    fn from(contract_hash: ContractPackageHash) -> Self {
-        Self::Contract(contract_hash)
+    fn from(contract_package_hash: ContractPackageHash) -> Self {
+        Self::Contract(contract_package_hash)
     }
 }
 

--- a/erc20/src/address.rs
+++ b/erc20/src/address.rs
@@ -3,16 +3,16 @@ use alloc::vec::Vec;
 use casper_types::{
     account::AccountHash,
     bytesrepr::{self, FromBytes, ToBytes},
-    CLType, CLTyped, ContractHash, Key,
+    CLType, CLTyped, ContractPackageHash, Key,
 };
 
-/// An enum representing an [`AccountHash`] or a [`ContractHash`].
+/// An enum representing an [`AccountHash`] or a [`ContractPackageHash`].
 #[derive(PartialOrd, Ord, PartialEq, Eq, Hash, Clone, Copy, Debug)]
 pub enum Address {
     /// Represents an account hash.
     Account(AccountHash),
-    /// Represents a contract hash.
-    Contract(ContractHash),
+    /// Represents a contract package hash.
+    Contract(ContractPackageHash),
 }
 
 impl Address {
@@ -26,7 +26,7 @@ impl Address {
     }
 
     /// Returns the inner contract hash if `self` is the `Contract` variant.
-    pub fn as_contract_hash(&self) -> Option<&ContractHash> {
+    pub fn as_contract_package_hash(&self) -> Option<&ContractPackageHash> {
         if let Self::Contract(v) = self {
             Some(v)
         } else {
@@ -35,8 +35,8 @@ impl Address {
     }
 }
 
-impl From<ContractHash> for Address {
-    fn from(contract_hash: ContractHash) -> Self {
+impl From<ContractPackageHash> for Address {
+    fn from(contract_hash: ContractPackageHash) -> Self {
         Self::Contract(contract_hash)
     }
 }
@@ -51,7 +51,7 @@ impl From<Address> for Key {
     fn from(address: Address) -> Self {
         match address {
             Address::Account(account_hash) => Key::Account(account_hash),
-            Address::Contract(contract_hash) => Key::Hash(contract_hash.value()),
+            Address::Contract(contract_package_hash) => Key::Hash(contract_package_hash.value()),
         }
     }
 }
@@ -78,9 +78,9 @@ impl FromBytes for Address {
 
         let address = match key {
             Key::Account(account_hash) => Address::Account(account_hash),
-            Key::Hash(raw_contract_hash) => {
-                let contract_hash = ContractHash::new(raw_contract_hash);
-                Address::Contract(contract_hash)
+            Key::Hash(raw_contract_package_hash) => {
+                let contract_package_hash = ContractPackageHash::new(raw_contract_package_hash);
+                Address::Contract(contract_package_hash)
             }
             _ => return Err(bytesrepr::Error::Formatting),
         };

--- a/erc20/src/detail.rs
+++ b/erc20/src/detail.rs
@@ -49,7 +49,6 @@ fn call_stack_element_to_address(call_stack_element: CallStackElement) -> Addres
             contract_package_hash,
             ..
         } => {
-            // Co
             Address::from(contract_package_hash)
         }
     }

--- a/erc20/src/detail.rs
+++ b/erc20/src/detail.rs
@@ -45,7 +45,13 @@ fn call_stack_element_to_address(call_stack_element: CallStackElement) -> Addres
             // with an ERC20 token caller's address will be used.
             Address::from(account_hash)
         }
-        CallStackElement::StoredContract { contract_hash, .. } => Address::from(contract_hash),
+        CallStackElement::StoredContract {
+            contract_package_hash,
+            ..
+        } => {
+            // Co
+            Address::from(contract_package_hash)
+        }
     }
 }
 

--- a/erc20/src/detail.rs
+++ b/erc20/src/detail.rs
@@ -48,9 +48,7 @@ fn call_stack_element_to_address(call_stack_element: CallStackElement) -> Addres
         CallStackElement::StoredContract {
             contract_package_hash,
             ..
-        } => {
-            Address::from(contract_package_hash)
-        }
+        } => Address::from(contract_package_hash),
     }
 }
 

--- a/example/erc20-tests/Cargo.toml
+++ b/example/erc20-tests/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 base64 = "0.13.0"
 blake2 = "0.9.2"
 casper-engine-test-support = { version = "1.3.2", features = ["test-support"] }
-casper-erc20 = { version = "0.1.0", features = ["std"], path = "../../erc20" }
+casper-erc20 = { version = "0.2.0", features = ["std"], path = "../../erc20" }
 casper-types = { version = "1.3.2", features = ["std"] }
 hex = "0.4.3"
 

--- a/testing/erc20-test-call/src/main.rs
+++ b/testing/erc20-test-call/src/main.rs
@@ -3,7 +3,10 @@
 
 extern crate alloc;
 
-use alloc::{string::String, vec};
+use alloc::{
+    string::{String, ToString},
+    vec,
+};
 
 use casper_contract::{
     self,
@@ -219,7 +222,10 @@ pub extern "C" fn call() {
     entry_points.add_entry_point(approve_as_stored_contract_entrypoint);
     entry_points.add_entry_point(transfer_from_as_stored_contract_entrypoint);
 
-    let (contract_hash, _version) = storage::new_contract(entry_points, None, None, None);
-
-    runtime::put_key(ERC20_TEST_CALL_KEY, contract_hash.into());
+    let (_contract_hash, _version) = storage::new_contract(
+        entry_points,
+        None,
+        Some(ERC20_TEST_CALL_KEY.to_string()),
+        None,
+    );
 }

--- a/testing/erc20-test/src/main.rs
+++ b/testing/erc20-test/src/main.rs
@@ -15,8 +15,8 @@ use casper_erc20::{
     Address, Error, ERC20,
 };
 use casper_types::{
-    account::AccountHash, CLType, CLTyped, CLValue, ContractHash, EntryPoint, EntryPointAccess,
-    EntryPointType, EntryPoints, Parameter, U256,
+    account::AccountHash, CLType, CLTyped, CLValue, ContractPackageHash, EntryPoint,
+    EntryPointAccess, EntryPointType, EntryPoints, Parameter, U256,
 };
 
 const MINT_ENTRY_POINT_NAME: &str = "mint";
@@ -32,7 +32,7 @@ const TOKEN_TOTAL_SUPPLY: u64 = 1_000_000_000;
 
 const TOKEN_OWNER_ADDRESS_1: Address = Address::Account(AccountHash::new([42; 32]));
 const TOKEN_OWNER_AMOUNT_1: u64 = 1_000_000;
-const TOKEN_OWNER_ADDRESS_2: Address = Address::Contract(ContractHash::new([42; 32]));
+const TOKEN_OWNER_ADDRESS_2: Address = Address::Contract(ContractPackageHash::new([42; 32]));
 const TOKEN_OWNER_AMOUNT_2: u64 = 2_000_000;
 
 #[derive(Default)]

--- a/testing/tests/src/lib_integration_tests.rs
+++ b/testing/tests/src/lib_integration_tests.rs
@@ -9,8 +9,8 @@ use casper_execution_engine::core::{
     execution::Error as ExecError,
 };
 use casper_types::{
-    account::AccountHash, runtime_args, system::mint, ApiError, ContractHash, Key, PublicKey,
-    RuntimeArgs, SecretKey, U256,
+    account::AccountHash, bytesrepr::FromBytes, runtime_args, system::mint, ApiError, CLTyped,
+    ContractHash, ContractPackageHash, Key, PublicKey, RuntimeArgs, SecretKey, U256,
 };
 
 const EXAMPLE_ERC20_TOKEN: &str = "erc20_token.wasm";
@@ -104,7 +104,7 @@ fn invert_erc20_address(address: Key) -> Key {
 struct TestContext {
     erc20_token: ContractHash,
     test_contract: ContractHash,
-    erc20_test_call: ContractHash,
+    erc20_test_call: ContractPackageHash,
 }
 
 fn setup() -> (InMemoryWasmTestBuilder, TestContext) {
@@ -180,7 +180,7 @@ fn setup() -> (InMemoryWasmTestBuilder, TestContext) {
         .named_keys()
         .get(ERC20_TEST_CALL_KEY)
         .and_then(|key| key.into_hash())
-        .map(ContractHash::new)
+        .map(ContractPackageHash::new)
         .expect("should have contract hash");
 
     let test_context = TestContext {
@@ -204,23 +204,42 @@ fn erc20_check_total_supply(
         .named_keys()
         .get(ERC20_TEST_CALL_KEY)
         .and_then(|key| key.into_hash())
-        .map(ContractHash::new)
+        .map(ContractPackageHash::new)
         .expect("should have test contract hash");
 
     let check_total_supply_args = runtime_args! {
         ARG_TOKEN_CONTRACT => *erc20_contract_hash,
     };
 
-    let exec_request = ExecuteRequestBuilder::contract_call_by_hash(
+    let exec_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
         erc20_test_contract_hash,
+        None,
         CHECK_TOTAL_SUPPLY_ENTRYPOINT,
         check_total_supply_args,
     )
     .build();
     builder.exec(exec_request).expect_success().commit();
 
-    builder.get_value(erc20_test_contract_hash, RESULT_KEY)
+    // builder.get_value(erc20_test_contract_hash, RESULT_KEY)
+    get_test_result(builder, erc20_test_contract_hash)
+}
+
+fn get_test_result<T: FromBytes + CLTyped>(
+    builder: &mut InMemoryWasmTestBuilder,
+    erc20_test_contract_hash: ContractPackageHash,
+) -> T {
+    let contract_package = builder
+        .get_contract_package(erc20_test_contract_hash)
+        .expect("should have contract package");
+    let enabled_versions = contract_package.enabled_versions();
+    let (_version, contract_hash) = enabled_versions
+        .iter()
+        .rev()
+        .next()
+        .expect("should have latest version");
+
+    builder.get_value(*contract_hash, RESULT_KEY)
 }
 
 fn erc20_check_balance_of(
@@ -236,23 +255,24 @@ fn erc20_check_balance_of(
         .named_keys()
         .get(ERC20_TEST_CALL_KEY)
         .and_then(|key| key.into_hash())
-        .map(ContractHash::new)
+        .map(ContractPackageHash::new)
         .expect("should have test contract hash");
 
     let check_balance_args = runtime_args! {
         ARG_TOKEN_CONTRACT => *erc20_contract_hash,
         ARG_ADDRESS => address,
     };
-    let exec_request = ExecuteRequestBuilder::contract_call_by_hash(
+    let exec_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
         erc20_test_contract_hash,
+        None,
         CHECK_BALANCE_OF_ENTRYPOINT,
         check_balance_args,
     )
     .build();
     builder.exec(exec_request).expect_success().commit();
 
-    builder.get_value(erc20_test_contract_hash, RESULT_KEY)
+    get_test_result(builder, erc20_test_contract_hash)
 }
 
 fn erc20_check_allowance_of(
@@ -273,7 +293,7 @@ fn erc20_check_allowance_of(
         .named_keys()
         .get(ERC20_TEST_CALL_KEY)
         .and_then(|key| key.into_hash())
-        .map(ContractHash::new)
+        .map(ContractPackageHash::new)
         .expect("should have test contract hash");
 
     let check_balance_args = runtime_args! {
@@ -281,16 +301,17 @@ fn erc20_check_allowance_of(
         ARG_OWNER => owner,
         ARG_SPENDER => spender,
     };
-    let exec_request = ExecuteRequestBuilder::contract_call_by_hash(
+    let exec_request = ExecuteRequestBuilder::versioned_contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
         erc20_test_contract_hash,
+        None,
         CHECK_ALLOWANCE_OF_ENTRYPOINT,
         check_balance_args,
     )
     .build();
     builder.exec(exec_request).expect_success().commit();
 
-    builder.get_value(erc20_test_contract_hash, RESULT_KEY)
+    get_test_result(builder, erc20_test_contract_hash)
 }
 
 fn test_erc20_transfer(
@@ -373,9 +394,10 @@ fn make_erc20_transfer_request(
             },
         )
         .build(),
-        Key::Hash(contract_hash) => ExecuteRequestBuilder::contract_call_by_hash(
+        Key::Hash(contract_package_hash) => ExecuteRequestBuilder::versioned_contract_call_by_hash(
             *DEFAULT_ACCOUNT_ADDR,
-            ContractHash::new(contract_hash),
+            ContractPackageHash::new(contract_package_hash),
+            None,
             METHOD_TRANSFER_AS_STORED_CONTRACT,
             runtime_args! {
                 ARG_TOKEN_CONTRACT => *erc20_token,
@@ -405,9 +427,10 @@ fn make_erc20_approve_request(
             },
         )
         .build(),
-        Key::Hash(contract_hash) => ExecuteRequestBuilder::contract_call_by_hash(
+        Key::Hash(contract_hash) => ExecuteRequestBuilder::versioned_contract_call_by_hash(
             *DEFAULT_ACCOUNT_ADDR,
-            ContractHash::new(contract_hash),
+            ContractPackageHash::new(contract_hash),
+            None,
             METHOD_APPROVE_AS_STORED_CONTRACT,
             runtime_args! {
                 ARG_TOKEN_CONTRACT => *erc20_token,
@@ -937,9 +960,10 @@ fn should_transfer_from_account_by_contract() {
     )
     .build();
 
-    let transfer_from_request_1 = ExecuteRequestBuilder::contract_call_by_hash(
+    let transfer_from_request_1 = ExecuteRequestBuilder::versioned_contract_call_by_hash(
         *DEFAULT_ACCOUNT_ADDR,
         erc20_test_call,
+        None,
         METHOD_FROM_AS_STORED_CONTRACT,
         erc20_transfer_from_args,
     )

--- a/testing/tests/src/lib_integration_tests.rs
+++ b/testing/tests/src/lib_integration_tests.rs
@@ -221,7 +221,6 @@ fn erc20_check_total_supply(
     .build();
     builder.exec(exec_request).expect_success().commit();
 
-    // builder.get_value(erc20_test_contract_hash, RESULT_KEY)
     get_test_result(builder, erc20_test_contract_hash)
 }
 


### PR DESCRIPTION
This PR addresses @zie1ony's feedback on token ownership and also bumps the version to 0.2.0.

This change changes the ownership for stored contracts from their
contract hash to their contract package. The concern here is that
upgrading a "holder" contract would essentially lock the tokens and
make them unusable. With changing the ownership into the
package hash, then regardless of which version is calling, the ownership
is maintained.