### PR TITLE
Update balances.rs

### DIFF
--- a/erc20/src/balances.rs
+++ b/erc20/src/balances.rs
@@ -56,6 +56,8 @@ pub(crate) fn transfer_balance(
             .checked_sub(amount)
             .ok_or(Error::InsufficientBalance)?
     };
+        
+    write_balance_to(balances_uref, sender, new_sender_balance);
 
     let new_recipient_balance = {
         let recipient_balance = read_balance_from(balances_uref, recipient);
@@ -64,7 +66,6 @@ pub(crate) fn transfer_balance(
             .ok_or(Error::Overflow)?
     };
 
-    write_balance_to(balances_uref, sender, new_sender_balance);
     write_balance_to(balances_uref, recipient, new_recipient_balance);
 
     Ok(())


### PR DESCRIPTION
Fix to prevent balance duplication.

The longer term fix is to compare urefs and no op but deferring the efficient fix for expediency.