### PR TITLE
Ensure transfers are correct when sender is recipient.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "casper-erc20"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "casper-contract",

--- a/erc20/Cargo.toml
+++ b/erc20/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-erc20"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["Michał Papierski <michal@casperlabs.io>"]
 description = "A library for developing ERC20 tokens for the Casper network."

--- a/erc20/src/balances.rs
+++ b/erc20/src/balances.rs
@@ -61,8 +61,6 @@ pub(crate) fn transfer_balance(
             .ok_or(Error::InsufficientBalance)?
     };
 
-    write_balance_to(balances_uref, sender, new_sender_balance);
-
     let new_recipient_balance = {
         let recipient_balance = read_balance_from(balances_uref, recipient);
         recipient_balance
@@ -70,6 +68,7 @@ pub(crate) fn transfer_balance(
             .ok_or(Error::Overflow)?
     };
 
+    write_balance_to(balances_uref, sender, new_sender_balance);
     write_balance_to(balances_uref, recipient, new_recipient_balance);
 
     Ok(())

--- a/erc20/src/balances.rs
+++ b/erc20/src/balances.rs
@@ -50,6 +50,10 @@ pub(crate) fn transfer_balance(
     recipient: Address,
     amount: U256,
 ) -> Result<(), Error> {
+    if sender == recipient || amount.is_zero() {
+        return Ok(());
+    }
+
     let new_sender_balance = {
         let sender_balance = read_balance_from(balances_uref, sender);
         sender_balance

--- a/erc20/src/balances.rs
+++ b/erc20/src/balances.rs
@@ -57,6 +57,8 @@ pub(crate) fn transfer_balance(
             .ok_or(Error::InsufficientBalance)?
     };
 
+    write_balance_to(balances_uref, sender, new_sender_balance);
+
     let new_recipient_balance = {
         let recipient_balance = read_balance_from(balances_uref, recipient);
         recipient_balance
@@ -64,7 +66,6 @@ pub(crate) fn transfer_balance(
             .ok_or(Error::Overflow)?
     };
 
-    write_balance_to(balances_uref, sender, new_sender_balance);
     write_balance_to(balances_uref, recipient, new_recipient_balance);
 
     Ok(())

--- a/erc20/src/lib.rs
+++ b/erc20/src/lib.rs
@@ -167,6 +167,9 @@ impl ERC20 {
         amount: U256,
     ) -> Result<(), Error> {
         let spender = detail::get_immediate_caller_address()?;
+        if amount.is_zero() {
+            return Ok(());
+        }
         let spender_allowance = self.read_allowance(owner, spender);
         let new_spender_allowance = spender_allowance
             .checked_sub(amount)

--- a/testing/tests/src/lib_integration_tests.rs
+++ b/testing/tests/src/lib_integration_tests.rs
@@ -1153,3 +1153,93 @@ fn test_should_not_mint_above_limits() {
         error
     );
 }
+
+#[test]
+fn should_have_correct_balance_after_own_transfer() {
+    let (mut builder, TestContext { erc20_token, .. }) = setup();
+
+    let sender = Key::Account(*DEFAULT_ACCOUNT_ADDR);
+    let recipient = Key::Account(*DEFAULT_ACCOUNT_ADDR);
+
+    let transfer_amount = U256::from(TRANSFER_AMOUNT_1);
+
+    let sender_balance_before = erc20_check_balance_of(&mut builder, &erc20_token, sender);
+    let recipient_balance_before = erc20_check_balance_of(&mut builder, &erc20_token, recipient);
+
+    assert_eq!(sender_balance_before, recipient_balance_before);
+
+    let token_transfer_request_1 =
+        make_erc20_transfer_request(sender, &erc20_token, recipient, transfer_amount);
+
+    builder
+        .exec(token_transfer_request_1)
+        .expect_success()
+        .commit();
+
+    let sender_balance_after = erc20_check_balance_of(&mut builder, &erc20_token, sender);
+    assert_eq!(sender_balance_before, sender_balance_after);
+
+    let recipient_balance_after = erc20_check_balance_of(&mut builder, &erc20_token, recipient);
+    assert_eq!(recipient_balance_before, recipient_balance_after);
+
+    assert_eq!(sender_balance_after, recipient_balance_after);
+}
+
+#[test]
+fn should_have_correct_balance_after_own_transfer_from() {
+    let (mut builder, TestContext { erc20_token, .. }) = setup();
+
+    let owner = Key::Account(*DEFAULT_ACCOUNT_ADDR);
+    let spender = Key::Account(*DEFAULT_ACCOUNT_ADDR);
+    let sender = Key::Account(*DEFAULT_ACCOUNT_ADDR);
+    let recipient = Key::Account(*DEFAULT_ACCOUNT_ADDR);
+
+    let allowance_amount = U256::from(ALLOWANCE_AMOUNT_1);
+    let transfer_amount = U256::from(TRANSFER_AMOUNT_1);
+
+    let approve_request =
+        make_erc20_approve_request(sender, &erc20_token, spender, allowance_amount);
+
+    builder.exec(approve_request).expect_success().commit();
+
+    let spender_allowance_before = erc20_check_allowance_of(&mut builder, owner, spender);
+
+    let sender_balance_before = erc20_check_balance_of(&mut builder, &erc20_token, sender);
+    let recipient_balance_before = erc20_check_balance_of(&mut builder, &erc20_token, recipient);
+
+    assert_eq!(sender_balance_before, recipient_balance_before);
+
+    let transfer_from_request = {
+        let erc20_transfer_from_args = runtime_args! {
+            ARG_OWNER => owner,
+            ARG_RECIPIENT => recipient,
+            ARG_AMOUNT => transfer_amount,
+        };
+        ExecuteRequestBuilder::contract_call_by_hash(
+            sender.into_account().unwrap(),
+            erc20_token,
+            METHOD_TRANSFER_FROM,
+            erc20_transfer_from_args,
+        )
+        .build()
+    };
+
+    builder
+        .exec(transfer_from_request)
+        .expect_success()
+        .commit();
+
+    let sender_balance_after = erc20_check_balance_of(&mut builder, &erc20_token, sender);
+    assert_eq!(sender_balance_before, sender_balance_after);
+
+    let recipient_balance_after = erc20_check_balance_of(&mut builder, &erc20_token, recipient);
+    assert_eq!(recipient_balance_before, recipient_balance_after);
+
+    assert_eq!(sender_balance_after, recipient_balance_after);
+
+    let spender_allowance_after = erc20_check_allowance_of(&mut builder, owner, spender);
+    assert_eq!(
+        spender_allowance_after,
+        spender_allowance_before - transfer_amount
+    );
+}


### PR DESCRIPTION
See also #31 reported by @davidtai

When sending tokens to yourself, the balance after the transfer should equal the balance before the transfer.