### PR TITLE
Update TUTORIAL name

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,4 +1,4 @@
-# ERC-20 Tutorial
+# Fungible Tokens on Casper - Tutorial
 
 This tutorial introduces an implementation of the ERC-20 standard for the Casper blockchain. The code for this tutorial is available in [GitHub](https://github.com/casper-ecosystem/erc20).
 


### PR DESCRIPTION
We shouldn't refer to ERC-20 directly, as it is not a Casper standard. Updating the tutorial title to something more general.