### PR TITLE
Fix Broken Link in CEP-18 Docs

### DIFF
--- a/docs/3-transfer.md
+++ b/docs/3-transfer.md
@@ -1,6 +1,6 @@
 # CEP-18 Token Transfers and Allowances
 
-This document describes how to transfer CEP-18 tokens on a Casper network using the Casper client. The [Exploring the CEP18 Contracts](./query.md) documentation contains more in depth explanations on how to find the various hashes and URefs referenced throughout this document.
+This document describes how to transfer CEP-18 tokens on a Casper network using the Casper client. The [Exploring the CEP18 Contracts](./2-query.md) documentation contains more in depth explanations on how to find the various hashes and URefs referenced throughout this document.
 
 ## Transferring CEP-18 Tokens to Another Account
 


### PR DESCRIPTION
### What does this PR fix/introduce?
This PR fixes a broken link in the [CEP-18 Token Transfers and Allowances](https://github.com/casper-ecosystem/cep18/blob/dev/docs/3-transfer.md)

### Additional context
[Slack Conversation](https://casper-labs-team.slack.com/archives/C05CJLK3GF4/p1686849979559749?thread_ts=1686835163.422539&cid=C05CJLK3GF4)

### Checklist
(Delete any that aren't relevant)

- [x] For new **internal** links I used *relative file paths* (with .md extension) - e.g. `../../faq/faq-general.md` - instead of introducing *absolute file path*, or *relative/absolute URL*.
- [x] My changes follow the [Casper docs style guidelines](https://docs.casper.network/resources/contribute-to-docs/).

### Reviewers
@deuszex 