### PR TITLE
Update wasm in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ make test
 Find the Wasm for the contract in the following directory:
 
 ```
-casper/cep18/target/wasm32-unknown-unknown/release/cep18_token.wasm
+casper/cep18/target/wasm32-unknown-unknown/release/cep18.wasm
 ```
 
 ## A JavaScript Client SDK


### PR DESCRIPTION
We need to update the command to reflect the current wasm file, which is cep18.wasm.

<img width="770" alt="Screenshot 2023-10-02 at 18 20 06" src="https://github.com/casper-ecosystem/cep18/assets/4185994/98ad14d7-0f0f-4079-bec0-5847fbfea38a">

