### PR TITLE
Emit event on install

### DIFF
--- a/cep18/src/main.rs
+++ b/cep18/src/main.rs
@@ -308,6 +308,11 @@ pub extern "C" fn init() {
             );
         }
     }
+    events::record_event_dictionary(Event::Transfer(Transfer {
+        sender: caller.into(),
+        recipient: caller.into(),
+        amount: initial_supply,
+    }))
 }
 
 /// Admin EntryPoint to manipulate the security access granted to users.

--- a/cep18/src/main.rs
+++ b/cep18/src/main.rs
@@ -308,8 +308,7 @@ pub extern "C" fn init() {
             );
         }
     }
-    events::record_event_dictionary(Event::Transfer(Transfer {
-        sender: caller.into(),
+    events::record_event_dictionary(Event::Mint(Mint {
         recipient: caller.into(),
         amount: initial_supply,
     }))


### PR DESCRIPTION
Emit a Transfer event on install_contract() to register token's existence.  It would be best if some event was emitted on install.