### PR TITLE
1.1

### DIFF
--- a/cep18-test-contract/Cargo.toml
+++ b/cep18-test-contract/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cep18-test-contract"
-version = "1.0.3"
+version = "1.1.0"
 authors = ["Michał Papierski <michal@casperlabs.io>"]
 edition = "2018"
 

--- a/cep18/Cargo.toml
+++ b/cep18/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cep18"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2018"
 description = "A library for developing CEP-18 tokens for the Casper network."
 readme = "README.md"

--- a/cep18/src/error.rs
+++ b/cep18/src/error.rs
@@ -47,6 +47,7 @@ pub enum Cep18Error {
     MintBurnDisabled = 60016,
     CannotTargetSelfUser = 60017,
     InvalidBurnTarget = 60018,
+    MissingPackageHashForUpgrade = 60019,
 }
 
 impl From<Cep18Error> for ApiError {

--- a/cep18/src/main.rs
+++ b/cep18/src/main.rs
@@ -378,7 +378,8 @@ pub fn upgrade(name: &str) {
     let (contract_hash, contract_version) =
         storage::add_contract_version(contract_package_hash, entry_points, NamedKeys::new());
 
-    storage::disable_contract_version(contract_package_hash, previous_contract_version).unwrap_or_revert();
+    storage::disable_contract_version(contract_package_hash, previous_contract_version)
+        .unwrap_or_revert();
     runtime::put_key(
         &format!("{CONTRACT_NAME_PREFIX}{name}"),
         contract_hash.into(),

--- a/cep18/src/main.rs
+++ b/cep18/src/main.rs
@@ -32,7 +32,7 @@ use casper_contract::{
     unwrap_or_revert::UnwrapOrRevert,
 };
 use casper_types::{
-    bytesrepr::ToBytes, contracts::NamedKeys, runtime_args, CLValue, Key, RuntimeArgs, U256,
+    bytesrepr::ToBytes, contracts::NamedKeys, runtime_args, CLValue, ContractHash, ContractPackageHash, Key, RuntimeArgs, U256
 };
 
 use constants::{

--- a/cep18/src/main.rs
+++ b/cep18/src/main.rs
@@ -367,7 +367,7 @@ pub extern "C" fn migrate(name: &str) {
     let contract_package_hash = runtime::get_key(&format!("{HASH_KEY_NAME_PREFIX}{name}")).unwrap_or_revert()
     .into_hash()
     .map(ContractPackageHash::new)
-    .unwrap_or_revert_with(Cep18Error::MissingPackageHashForUpgrade);;
+    .unwrap_or_revert_with(Cep18Error::MissingPackageHashForUpgrade);
 
     let previous_contract_version = runtime::get_key(&format!("{HASH_KEY_NAME_PREFIX}{name}")).unwrap_or_revert()
     .into_hash()

--- a/cep18/src/main.rs
+++ b/cep18/src/main.rs
@@ -369,7 +369,7 @@ pub fn upgrade(name: &str) {
         .map(ContractPackageHash::new)
         .unwrap_or_revert_with(Cep18Error::MissingPackageHashForUpgrade);
 
-    let previous_contract_version = runtime::get_key(&format!("{HASH_KEY_NAME_PREFIX}{name}"))
+    let previous_contract_version = runtime::get_key(&format!("{CONTRACT_NAME_PREFIX}{name}"))
         .unwrap_or_revert()
         .into_hash()
         .map(ContractHash::new)

--- a/client-js/src/error.ts
+++ b/client-js/src/error.ts
@@ -25,18 +25,20 @@ export enum ERROR_CODES {
   InvalidAdminList = 60011,
   /// The list of accounts that can mint tokens is invalid.
   InvalidMinterList = 60012,
-  ///  The list of accounts that can burn tokens is invalid.
-  InvalidBurnerList = 60013,
-  /// The list of accounts that can mint and burn is invalid.
-  InvalidMintAndBurnList = 60014,
   /// The list of accounts with no access rights is invalid.
-  InvalidNoneList = 60015,
+  InvalidNoneList = 60013,
   /// The flag to enable the mint and burn mode is invalid.
-  InvalidEnableMBFlag = 60016,
+  InvalidEnableMBFlag = 60014,
   /// This contract instance cannot be initialized again.
-  AlreadyInitialized = 60017,
-  ///  The mint and burn mode is disabled.
-  MintBurnDisabled = 60018
+  AlreadyInitialized = 60015,
+  /// The mint and burn mode is disabled.
+  MintBurnDisabled = 60016,
+  /// User cannot target themselves with allowance features.
+  CannotTargetSelfUser = 60017,
+  /// Tried to burn the tokens of someone else.
+  InvalidBurnTarget = 60018,
+  /// There is an AccessToken but no valid ContractPackageHash. Try to query the account for NamedKeys to find it.
+  MissingPackageHashForUpgrade = 60019,
 }
 
 export class ContractError extends Error {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2018"
 authors = ["Michał Papierski <michal@casperlabs.io>"]
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -3,10 +3,10 @@ mod allowance;
 #[cfg(test)]
 mod install;
 #[cfg(test)]
+mod migration;
+#[cfg(test)]
 mod mint_and_burn;
 #[cfg(test)]
 mod transfer;
 #[cfg(test)]
 mod utility;
-#[cfg(test)]
-mod migration;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -8,3 +8,5 @@ mod mint_and_burn;
 mod transfer;
 #[cfg(test)]
 mod utility;
+#[cfg(test)]
+mod migration;

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -1,5 +1,5 @@
 use casper_engine_test_support::{ExecuteRequestBuilder, DEFAULT_ACCOUNT_ADDR};
-use casper_types::{runtime_args, ContractHash, RuntimeArgs, U256};
+use casper_types::{runtime_args, Key, RuntimeArgs, U256};
 
 use crate::utility::{
     constants::{
@@ -10,18 +10,21 @@ use crate::utility::{
 };
 
 #[test]
-fn should_have_queryable_properties() {
+fn should_upgrade_contract_version() {
     let (mut builder, TestContext { cep18_token: _, .. }) = setup();
-    let pre_account = builder
-        .get_account(*DEFAULT_ACCOUNT_ADDR)
-        .expect("should have account");
 
-    let version_0 = pre_account
-        .named_keys()
-        .get("cep18_contract_version_CasperTest")
-        .and_then(|key| key.into_hash())
-        .map(ContractHash::new)
-        .expect("should have contract hash");
+    let version_0: u32 = builder
+        .query(
+            None,
+            Key::Account(*DEFAULT_ACCOUNT_ADDR),
+            &["cep18_contract_version_CasperTest".to_string()],
+        )
+        .unwrap()
+        .as_cl_value()
+        .unwrap()
+        .clone()
+        .into_t()
+        .unwrap();
 
     let install_request_1 = ExecuteRequestBuilder::standard(
         *DEFAULT_ACCOUNT_ADDR,
@@ -37,16 +40,18 @@ fn should_have_queryable_properties() {
 
     builder.exec(install_request_1).expect_success().commit();
 
-    let post_account = builder
-        .get_account(*DEFAULT_ACCOUNT_ADDR)
-        .expect("should have account");
-
-    let version_1 = post_account
-        .named_keys()
-        .get("cep18_contract_version_CasperTest")
-        .and_then(|key| key.into_hash())
-        .map(ContractHash::new)
-        .expect("should have contract hash");
+    let version_1: u32 = builder
+        .query(
+            None,
+            Key::Account(*DEFAULT_ACCOUNT_ADDR),
+            &["cep18_contract_version_CasperTest".to_string()],
+        )
+        .unwrap()
+        .as_cl_value()
+        .unwrap()
+        .clone()
+        .into_t()
+        .unwrap();
 
     assert!(version_0 < version_1);
 }

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -1,13 +1,13 @@
-use casper_engine_test_support::DEFAULT_ACCOUNT_ADDR;
-use casper_types::runtime_args;
+use casper_engine_test_support::{ExecuteRequestBuilder, DEFAULT_ACCOUNT_ADDR};
+use casper_types::{runtime_args, ContractHash, RuntimeArgs, U256};
 
 use crate::utility::{
     constants::{
         ARG_DECIMALS, ARG_NAME, ARG_SYMBOL, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM,
-        CEP18_TOKEN_CONTRACT_KEY, DECIMALS_KEY, NAME_KEY, SYMBOL_KEY, TOKEN_DECIMALS, TOKEN_NAME,
-        TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, TOTAL_SUPPLY_KEY,
+        TOKEN_DECIMALS, TOKEN_NAME,
+        TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, 
     },
-    installer_request_builders::setup,
+    installer_request_builders::{setup, TestContext},
 };
 
 #[test]
@@ -17,7 +17,7 @@ fn should_have_queryable_properties() {
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");
 
-    let version_0 = account
+    let version_0 = pre_account
         .named_keys()
         .get("cep18_contract_version_CasperTest")
         .and_then(|key| key.into_hash())
@@ -36,11 +36,13 @@ fn should_have_queryable_properties() {
     )
     .build();
 
+    builder.exec(install_request_1).expect_success().commit();
+
     let post_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");
 
-    let version_1 = account
+    let version_1 = post_account
         .named_keys()
         .get("cep18_contract_version_CasperTest")
         .and_then(|key| key.into_hash())

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -12,7 +12,7 @@ use crate::utility::{
 
 #[test]
 fn should_have_queryable_properties() {
-    let (mut builder, TestContext { cep18_token, .. }) = setup();
+    let (mut builder, TestContext { cep18_token : _ , .. }) = setup();
     let pre_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -4,14 +4,14 @@ use casper_types::{runtime_args, ContractHash, RuntimeArgs, U256};
 use crate::utility::{
     constants::{
         ARG_DECIMALS, ARG_NAME, ARG_SYMBOL, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM, TOKEN_DECIMALS,
-        TOKEN_NAME, TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, 
+        TOKEN_NAME, TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY,
     },
     installer_request_builders::{setup, TestContext},
 };
 
 #[test]
 fn should_have_queryable_properties() {
-    let (mut builder, TestContext { cep18_token: _ , .. }) = setup();
+    let (mut builder, TestContext { cep18_token: _, .. }) = setup();
     let pre_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -3,16 +3,15 @@ use casper_types::{runtime_args, ContractHash, RuntimeArgs, U256};
 
 use crate::utility::{
     constants::{
-        ARG_DECIMALS, ARG_NAME, ARG_SYMBOL, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM,
-        TOKEN_DECIMALS, TOKEN_NAME,
-        TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, 
+        ARG_DECIMALS, ARG_NAME, ARG_SYMBOL, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM, TOKEN_DECIMALS,
+        TOKEN_NAME, TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, 
     },
     installer_request_builders::{setup, TestContext},
 };
 
 #[test]
 fn should_have_queryable_properties() {
-    let (mut builder, TestContext { cep18_token : _ , .. }) = setup();
+    let (mut builder, TestContext { cep18_token: _ , .. }) = setup();
     let pre_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)
         .expect("should have account");

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -1,7 +1,14 @@
 use casper_engine_test_support::DEFAULT_ACCOUNT_ADDR;
 use casper_types::runtime_args;
 
-use crate::utility::{constants::{ARG_DECIMALS, ARG_NAME, ARG_SYMBOL, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM, CEP18_TOKEN_CONTRACT_KEY, DECIMALS_KEY, NAME_KEY, SYMBOL_KEY, TOKEN_DECIMALS, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, TOTAL_SUPPLY_KEY}, installer_request_builders::setup};
+use crate::utility::{
+    constants::{
+        ARG_DECIMALS, ARG_NAME, ARG_SYMBOL, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM,
+        CEP18_TOKEN_CONTRACT_KEY, DECIMALS_KEY, NAME_KEY, SYMBOL_KEY, TOKEN_DECIMALS, TOKEN_NAME,
+        TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, TOTAL_SUPPLY_KEY,
+    },
+    installer_request_builders::setup,
+};
 
 #[test]
 fn should_have_queryable_properties() {
@@ -17,14 +24,17 @@ fn should_have_queryable_properties() {
         .map(ContractHash::new)
         .expect("should have contract hash");
 
-    let install_request_1 =
-    ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, CEP18_CONTRACT_WASM, runtime_args! {
-        ARG_NAME => TOKEN_NAME,
-        ARG_SYMBOL => TOKEN_SYMBOL,
-        ARG_DECIMALS => TOKEN_DECIMALS,
-        ARG_TOTAL_SUPPLY => U256::from(TOKEN_TOTAL_SUPPLY),
-    })
-        .build();
+    let install_request_1 = ExecuteRequestBuilder::standard(
+        *DEFAULT_ACCOUNT_ADDR,
+        CEP18_CONTRACT_WASM,
+        runtime_args! {
+            ARG_NAME => TOKEN_NAME,
+            ARG_SYMBOL => TOKEN_SYMBOL,
+            ARG_DECIMALS => TOKEN_DECIMALS,
+            ARG_TOTAL_SUPPLY => U256::from(TOKEN_TOTAL_SUPPLY),
+        },
+    )
+    .build();
 
     let post_account = builder
         .get_account(*DEFAULT_ACCOUNT_ADDR)

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -1,0 +1,41 @@
+use casper_engine_test_support::DEFAULT_ACCOUNT_ADDR;
+use casper_types::runtime_args;
+
+use crate::utility::{constants::{ARG_DECIMALS, ARG_NAME, ARG_SYMBOL, ARG_TOTAL_SUPPLY, CEP18_CONTRACT_WASM, CEP18_TOKEN_CONTRACT_KEY, DECIMALS_KEY, NAME_KEY, SYMBOL_KEY, TOKEN_DECIMALS, TOKEN_NAME, TOKEN_SYMBOL, TOKEN_TOTAL_SUPPLY, TOTAL_SUPPLY_KEY}, installer_request_builders::setup};
+
+#[test]
+fn should_have_queryable_properties() {
+    let (mut builder, TestContext { cep18_token, .. }) = setup();
+    let pre_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+
+    let version_0 = account
+        .named_keys()
+        .get("cep18_contract_version_CasperTest")
+        .and_then(|key| key.into_hash())
+        .map(ContractHash::new)
+        .expect("should have contract hash");
+
+    let install_request_1 =
+    ExecuteRequestBuilder::standard(*DEFAULT_ACCOUNT_ADDR, CEP18_CONTRACT_WASM, runtime_args! {
+        ARG_NAME => TOKEN_NAME,
+        ARG_SYMBOL => TOKEN_SYMBOL,
+        ARG_DECIMALS => TOKEN_DECIMALS,
+        ARG_TOTAL_SUPPLY => U256::from(TOKEN_TOTAL_SUPPLY),
+    })
+        .build();
+
+    let post_account = builder
+        .get_account(*DEFAULT_ACCOUNT_ADDR)
+        .expect("should have account");
+
+    let version_1 = account
+        .named_keys()
+        .get("cep18_contract_version_CasperTest")
+        .and_then(|key| key.into_hash())
+        .map(ContractHash::new)
+        .expect("should have contract hash");
+
+    assert!(version_0 < version_1);
+}


### PR DESCRIPTION
Add migration so users can make use of the new Peregrine cost table. Closes #112 