### PR TITLE
no error is returned in get_optional_named_arg_with_user_errors

### DIFF
--- a/cep18/src/utils.rs
+++ b/cep18/src/utils.rs
@@ -108,7 +108,8 @@ pub fn get_optional_named_arg_with_user_errors<T: FromBytes>(
 ) -> Option<T> {
     match get_named_arg_with_user_errors::<T>(name, Cep18Error::Phantom, invalid) {
         Ok(val) => Some(val),
-        Err(_) => None,
+        Err(Cep18Error::Phantom) => None,
+        Err(_) => runtime::revert(invalid),
     }
 }
 


### PR DESCRIPTION
in `get_optional_named_arg_with_user_errors` no error is returned when the type does not match the expected type.