### PR TITLE
native expansive error topic

### DIFF
--- a/cep18/src/constants.rs
+++ b/cep18/src/constants.rs
@@ -14,6 +14,8 @@ pub const ALLOWANCES: &str = "allowances";
 pub const TOTAL_SUPPLY: &str = "total_supply";
 pub const EVENTS: &str = "events";
 pub const REVERT: &str = "revert";
+pub const ERRORS: &str = "errors";
+pub const CONDOR: &str = "condor";
 
 pub const HASH_KEY_NAME_PREFIX: &str = "cep18_contract_package_";
 pub const ACCESS_KEY_NAME_PREFIX: &str = "cep18_contract_package_access_";

--- a/cep18/src/entry_points.rs
+++ b/cep18/src/entry_points.rs
@@ -9,7 +9,7 @@ use casper_types::{
 use crate::constants::{
     ADDRESS, ALLOWANCE_ENTRY_POINT_NAME, AMOUNT, APPROVE_ENTRY_POINT_NAME,
     BALANCE_OF_ENTRY_POINT_NAME, BURN_ENTRY_POINT_NAME, CHANGE_EVENTS_MODE_ENTRY_POINT_NAME,
-    CHANGE_SECURITY_ENTRY_POINT_NAME, DECIMALS_ENTRY_POINT_NAME,
+    CHANGE_SECURITY_ENTRY_POINT_NAME, CONDOR, DECIMALS_ENTRY_POINT_NAME,
     DECREASE_ALLOWANCE_ENTRY_POINT_NAME, EVENTS, EVENTS_MODE, INCREASE_ALLOWANCE_ENTRY_POINT_NAME,
     INIT_ENTRY_POINT_NAME, MIGRATE_USER_ALLOWANCE_KEYS_ENTRY_POINT_NAME,
     MIGRATE_USER_BALANCE_KEYS_ENTRY_POINT_NAME, MIGRATE_USER_SEC_KEYS_ENTRY_POINT_NAME,
@@ -17,6 +17,18 @@ use crate::constants::{
     SYMBOL_ENTRY_POINT_NAME, TOTAL_SUPPLY_ENTRY_POINT_NAME, TRANSFER_ENTRY_POINT_NAME,
     TRANSFER_FROM_ENTRY_POINT_NAME,
 };
+
+/// Returns the `condor` entry point.
+pub fn condor() -> EntryPoint {
+    EntryPoint::new(
+        String::from(CONDOR),
+        Vec::new(),
+        String::cl_type(),
+        EntryPointAccess::Public,
+        EntryPointType::Called,
+        casper_types::EntryPointPayment::Caller,
+    )
+}
 
 /// Returns the `name` entry point.
 pub fn name() -> EntryPoint {
@@ -297,6 +309,7 @@ pub fn generate_entry_points() -> EntryPoints {
     let mut entry_points = EntryPoints::new();
     entry_points.add_entry_point(init());
     entry_points.add_entry_point(name());
+    entry_points.add_entry_point(condor());
     entry_points.add_entry_point(symbol());
     entry_points.add_entry_point(decimals());
     entry_points.add_entry_point(total_supply());

--- a/tests/src/migration.rs
+++ b/tests/src/migration.rs
@@ -248,7 +248,7 @@ fn should_have_native_events() {
     let (topic_name, message_topic_hash) = entity
         .message_topics()
         .iter()
-        .next()
+        .last()
         .expect("should have at least one topic");
 
     let mut user_map: BTreeMap<Key, bool> = BTreeMap::new();


### PR DESCRIPTION
MessageTopics commit their data onto global state even if the execution fails, which makes them the perfect candidate to use for error logging in case more expansive details are required about the source of an error than what the u16 error codes can confer.

Do not use in `unwrap_or_revert_with` because they will trigger even if there was no error to unwrap,
instead consider the following application
```
maybe_error.map_err(|err| {
    runtime::emit_message(ERRORS, &format!("custom error message, source error: {err:?}").into()).unwrap_or_revert(); 
    new_error
}).unwrap_or_revert()
```
this will prevent false positive error messages.